### PR TITLE
Forbid `super` in static class methods with server function directives

### DIFF
--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/26/input.js
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/26/input.js
@@ -1,10 +1,17 @@
-export class MyClass {
+import { BaseClass } from './base'
+
+export class MyClass extends BaseClass {
   static async foo() {
+    // super is allowed here
+    super.foo()
+
     return fetch('https://example.com').then((res) => res.json())
   }
   static async bar() {
     'use cache'
 
+    // super is not allowed here
+    super.bar()
     // arguments is not allowed here
     console.log(arguments)
     // this is not allowed here

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/26/output.js
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/26/output.js
@@ -1,6 +1,7 @@
 /* __next_internal_action_entry_do_not_use__ {"803128060c414d59f8552e4788b846c0d2b7f74743":"$$RSC_SERVER_CACHE_0"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
+import { BaseClass } from './base';
 export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", 0, /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ async function bar() {
     // arguments is not allowed here
     console.log(arguments);
@@ -11,8 +12,10 @@ Object.defineProperty($$RSC_SERVER_CACHE_0, "name", {
     "value": "bar",
     "writable": false
 });
-export class MyClass {
+export class MyClass extends BaseClass {
     static async foo() {
+        // super is allowed here
+        super.foo();
         return fetch('https://example.com').then((res)=>res.json());
     }
     static bar = registerServerReference($$RSC_SERVER_CACHE_0, "803128060c414d59f8552e4788b846c0d2b7f74743", null);

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/26/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/26/output.stderr
@@ -1,16 +1,24 @@
+  x "use cache" functions can not use `super`.
+  | 
+    ,-[input.js:14:1]
+ 13 |     // super is not allowed here
+ 14 |     super.bar()
+    :     ^^^^^
+ 15 |     // arguments is not allowed here
+    `----
   x "use cache" functions can not use `arguments`.
   | 
-    ,-[input.js:9:1]
-  8 |     // arguments is not allowed here
-  9 |     console.log(arguments)
+    ,-[input.js:16:1]
+ 15 |     // arguments is not allowed here
+ 16 |     console.log(arguments)
     :                 ^^^^^^^^^
- 10 |     // this is not allowed here
+ 17 |     // this is not allowed here
     `----
   x "use cache" functions can not use `this`.
   | 
-    ,-[input.js:11:1]
- 10 |     // this is not allowed here
- 11 |     return this.foo()
+    ,-[input.js:18:1]
+ 17 |     // this is not allowed here
+ 18 |     return this.foo()
     :            ^^^^
- 12 |   }
+ 19 |   }
     `----


### PR DESCRIPTION
Static class methods that are annotated with `"use cache"` or `"use server"` must not call `super`.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR enhances server actions validation in Next.js by forbidding 'super' usage in static class methods with server function directives. It implements checks for 'super' usage, removes invalid super calls, updates test cases, and refines error messages for 'super' violations in server actions.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>